### PR TITLE
Tighten collision bounding boxes to match visible sprite pixels

### DIFF
--- a/src/main/java/org/moqucu/games/nightstalker/model/DisplayableObject.java
+++ b/src/main/java/org/moqucu/games/nightstalker/model/DisplayableObject.java
@@ -194,6 +194,11 @@ public abstract class DisplayableObject extends GameObject implements Collidable
             );
     }
 
+    public void setBoundingBoxDimensions(double offsetX, double offsetY, double width, double height) {
+
+        collidable.setBoundingBox(new BoundingBox(offsetX, offsetX + width, offsetY, offsetY + height));
+    }
+
     public AbsolutePosition getAbsolutePosition() {
 
         return new AbsolutePosition(getXPosition(), getYPosition());

--- a/src/main/java/org/moqucu/games/nightstalker/model/enemy/Bat.java
+++ b/src/main/java/org/moqucu/games/nightstalker/model/enemy/Bat.java
@@ -32,6 +32,7 @@ public class Bat extends MovableObject implements Resettable {
         setVelocity(50);
         setMazeGraphFileName("/json/maze-graph-enemy.json");
         setMazeAlgorithm(MazeAlgorithm.Random);
+        setBoundingBoxDimensions(4, 4, 24, 14);
     }
 
     @Override

--- a/src/main/java/org/moqucu/games/nightstalker/model/enemy/GreyRobot.java
+++ b/src/main/java/org/moqucu/games/nightstalker/model/enemy/GreyRobot.java
@@ -28,6 +28,7 @@ public class GreyRobot extends MovableObject implements Resettable {
         setFrameRate(10);
         setMazeGraphFileName("/json/maze-graph-enemy.json");
         setMazeAlgorithm(MazeAlgorithm.Random);
+        setBoundingBoxDimensions(2, 2, 28, 28);
         reset();
         addPropertyChangeListener(evt -> {
 

--- a/src/main/java/org/moqucu/games/nightstalker/model/enemy/Spider.java
+++ b/src/main/java/org/moqucu/games/nightstalker/model/enemy/Spider.java
@@ -51,6 +51,7 @@ public class Spider extends MovableObject implements Resettable {
 
         setMazeGraphFileName("/json/maze-graph-enemy.json");
         setImageMapFileName("/images/spider.png");
+        setBoundingBoxDimensions(0, 4, 32, 22);
         reset();
         setAnimated(true);
         setInMotion(true);

--- a/src/main/java/org/moqucu/games/nightstalker/model/hero/NightStalker.java
+++ b/src/main/java/org/moqucu/games/nightstalker/model/hero/NightStalker.java
@@ -41,6 +41,7 @@ public class NightStalker extends MovableObject implements Resettable {
         setImageMapFileName("/images/night-stalker.png");
         setFrameRate(10);
         setVelocity(30);
+        setBoundingBoxDimensions(6, 1, 20, 30);
         reset();
     }
 

--- a/src/main/java/org/moqucu/games/nightstalker/model/object/Bullet.java
+++ b/src/main/java/org/moqucu/games/nightstalker/model/object/Bullet.java
@@ -30,6 +30,7 @@ public class Bullet extends DisplayableObject implements TimeListener, Resettabl
         super();
         setImageMapFileName("/images/bullet.png");
         setInitialImageIndex(0);
+        setBoundingBoxDimensions(12, 14, 8, 4);
         propertyChangeSupport.addPropertyChangeListener(
                 evt -> {
                     if (evt.getPropertyName().equals(PropertyNames.FIRED) && evt.getNewValue().equals(true)) {

--- a/src/main/java/org/moqucu/games/nightstalker/model/object/Weapon.java
+++ b/src/main/java/org/moqucu/games/nightstalker/model/object/Weapon.java
@@ -64,6 +64,7 @@ public class Weapon extends AnimatedObject implements Resettable {
         setLowerAnimationIndex(0);
         setUpperAnimationIndex(1);
         setFrameRate(2);
+        setBoundingBoxDimensions(0, 8, 32, 16);
         drop();
     }
 

--- a/src/test/java/org/moqucu/games/nightstalker/model/enemy/test/BatTest.java
+++ b/src/test/java/org/moqucu/games/nightstalker/model/enemy/test/BatTest.java
@@ -1,6 +1,7 @@
 package org.moqucu.games.nightstalker.model.enemy.test;
 
 import org.junit.jupiter.api.Test;
+import org.moqucu.games.nightstalker.model.BoundingBox;
 import org.moqucu.games.nightstalker.model.Direction;
 import org.moqucu.games.nightstalker.model.GameWorld;
 import org.moqucu.games.nightstalker.model.MazeAlgorithm;
@@ -274,5 +275,19 @@ public class BatTest {
         assertThat(localBat.isAwake(), is(true));
         assertThat(localBat.isInMotion(), is(true));
         assertThat(localBat.isAnimated(), is(true));
+    }
+
+    @Test
+    public void batHasTightBoundingBox() {
+
+        final Bat localBat = new Bat();
+        localBat.setSpawnXPosition(528.0);
+        localBat.setSpawnYPosition(96.0);
+
+        final BoundingBox bounds = localBat.getAbsoluteBounds();
+        assertThat(bounds.getMinX(), is(532.0));
+        assertThat(bounds.getMaxX(), is(556.0));
+        assertThat(bounds.getMinY(), is(100.0));
+        assertThat(bounds.getMaxY(), is(114.0));
     }
 }

--- a/src/test/java/org/moqucu/games/nightstalker/model/enemy/test/GreyRobotTest.java
+++ b/src/test/java/org/moqucu/games/nightstalker/model/enemy/test/GreyRobotTest.java
@@ -2,6 +2,7 @@ package org.moqucu.games.nightstalker.model.enemy.test;
 
 import org.junit.jupiter.api.Test;
 import org.moqucu.games.nightstalker.model.*;
+import org.moqucu.games.nightstalker.model.BoundingBox;
 import org.moqucu.games.nightstalker.model.enemy.GreyRobot;
 import org.moqucu.games.nightstalker.model.hero.NightStalker;
 import org.moqucu.games.nightstalker.model.object.Bullet;
@@ -215,5 +216,15 @@ public class GreyRobotTest {
         assertThat(greyRobot.isObjectVisible(), is(true));
         assertThat(greyRobot.isInMotion(), is(true));
         assertThat(greyRobot.isAnimated(), is(true));
+    }
+
+    @Test
+    public void greyRobotHasTightBoundingBox() {
+
+        final BoundingBox bounds = greyRobot.getAbsoluteBounds();
+        assertThat(bounds.getMinX(), is(greyRobot.getXPosition() + 2));
+        assertThat(bounds.getMaxX(), is(greyRobot.getXPosition() + 30));
+        assertThat(bounds.getMinY(), is(greyRobot.getYPosition() + 2));
+        assertThat(bounds.getMaxY(), is(greyRobot.getYPosition() + 30));
     }
 }

--- a/src/test/java/org/moqucu/games/nightstalker/model/enemy/test/SpiderTest.java
+++ b/src/test/java/org/moqucu/games/nightstalker/model/enemy/test/SpiderTest.java
@@ -1,6 +1,7 @@
 package org.moqucu.games.nightstalker.model.enemy.test;
 
 import org.junit.jupiter.api.Test;
+import org.moqucu.games.nightstalker.model.BoundingBox;
 import org.moqucu.games.nightstalker.model.Direction;
 import org.moqucu.games.nightstalker.model.GameWorld;
 import org.moqucu.games.nightstalker.model.MazeAlgorithm;
@@ -224,5 +225,15 @@ public class SpiderTest {
         assertThat(spider.isObjectVisible(), is(true));
         assertThat(spider.isInMotion(), is(true));
         assertThat(spider.isAnimated(), is(true));
+    }
+
+    @Test
+    public void spiderHasTightBoundingBox() {
+
+        final BoundingBox bounds = spider.getAbsoluteBounds();
+        assertThat(bounds.getMinX(), is(spider.getXPosition() + 0));
+        assertThat(bounds.getMaxX(), is(spider.getXPosition() + 32));
+        assertThat(bounds.getMinY(), is(spider.getYPosition() + 4));
+        assertThat(bounds.getMaxY(), is(spider.getYPosition() + 26));
     }
 }

--- a/src/test/java/org/moqucu/games/nightstalker/model/hero/test/NightStalkerTest.java
+++ b/src/test/java/org/moqucu/games/nightstalker/model/hero/test/NightStalkerTest.java
@@ -5,6 +5,7 @@ import org.moqucu.games.nightstalker.model.Direction;
 import org.moqucu.games.nightstalker.model.GameWorld;
 import org.moqucu.games.nightstalker.model.MovableObject;
 import org.moqucu.games.nightstalker.model.Resettable;
+import org.moqucu.games.nightstalker.model.BoundingBox;
 import org.moqucu.games.nightstalker.model.background.Wall;
 import org.moqucu.games.nightstalker.model.hero.NightStalker;
 import org.moqucu.games.nightstalker.model.object.Weapon;
@@ -399,5 +400,17 @@ public class NightStalkerTest {
 
         aNightStalker.fireWeapon();
         assertThat(aWeapon.getRounds(), is(5));
+    }
+
+    @Test
+    public void nightStalkerHasTightBoundingBox() {
+
+        final NightStalker nightStalker = new NightStalker();
+
+        final BoundingBox bounds = nightStalker.getAbsoluteBounds();
+        assertThat(bounds.getMinX(), is(nightStalker.getXPosition() + 6));
+        assertThat(bounds.getMaxX(), is(nightStalker.getXPosition() + 26));
+        assertThat(bounds.getMinY(), is(nightStalker.getYPosition() + 1));
+        assertThat(bounds.getMaxY(), is(nightStalker.getYPosition() + 31));
     }
 }

--- a/src/test/java/org/moqucu/games/nightstalker/model/object/test/BulletTest.java
+++ b/src/test/java/org/moqucu/games/nightstalker/model/object/test/BulletTest.java
@@ -369,4 +369,18 @@ public class BulletTest {
         assertThat(aBullet.getInitialImageIndex(), is(0));
     }
 
+    @Test
+    public void bulletHasTightBoundingBox() {
+
+        final Bullet bullet = new Bullet();
+        bullet.setXPosition(64);
+        bullet.setYPosition(128);
+
+        final BoundingBox bounds = bullet.getAbsoluteBounds();
+        assertThat(bounds.getMinX(), is(76.0));
+        assertThat(bounds.getMaxX(), is(84.0));
+        assertThat(bounds.getMinY(), is(142.0));
+        assertThat(bounds.getMaxY(), is(146.0));
+    }
+
 }

--- a/src/test/java/org/moqucu/games/nightstalker/model/object/test/WeaponTest.java
+++ b/src/test/java/org/moqucu/games/nightstalker/model/object/test/WeaponTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.moqucu.games.nightstalker.model.AbsolutePosition;
 import org.moqucu.games.nightstalker.model.AnimatedObject;
+import org.moqucu.games.nightstalker.model.BoundingBox;
 import org.moqucu.games.nightstalker.model.Direction;
 import org.moqucu.games.nightstalker.model.hero.NightStalker;
 import org.moqucu.games.nightstalker.model.object.Bullet;
@@ -187,6 +188,20 @@ public class WeaponTest {
         final Weapon aWeapon = new Weapon();
 
         assertThat(aWeapon.canChangePosition(), is(true));
+    }
+
+    @Test
+    public void weaponHasTightBoundingBox() {
+
+        final Weapon aWeapon = new Weapon();
+        aWeapon.setXPosition(64);
+        aWeapon.setYPosition(128);
+
+        final BoundingBox bounds = aWeapon.getAbsoluteBounds();
+        assertThat(bounds.getMinX(), is(64.0));
+        assertThat(bounds.getMaxX(), is(96.0));
+        assertThat(bounds.getMinY(), is(136.0));
+        assertThat(bounds.getMaxY(), is(152.0));
     }
 
     @Test

--- a/src/test/java/org/moqucu/games/nightstalker/model/test/DisplayableObjectTest.java
+++ b/src/test/java/org/moqucu/games/nightstalker/model/test/DisplayableObjectTest.java
@@ -3,6 +3,7 @@ package org.moqucu.games.nightstalker.model.test;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.moqucu.games.nightstalker.model.BoundingBox;
 import org.moqucu.games.nightstalker.model.Collidable;
 import org.moqucu.games.nightstalker.model.DisplayableObject;
 import org.moqucu.games.nightstalker.model.GameObject;
@@ -188,5 +189,19 @@ public class DisplayableObjectTest {
     public void implementsCollidableInterface() {
 
         assertThat(displayableObject, isA(Collidable.class));
+    }
+
+    @Test
+    public void setBoundingBoxDimensionsAffectsAbsoluteBounds() {
+
+        displayableObject.setXPosition(100);
+        displayableObject.setYPosition(200);
+        displayableObject.setBoundingBoxDimensions(4, 8, 20, 16);
+
+        final BoundingBox bounds = displayableObject.getAbsoluteBounds();
+        assertThat(bounds.getMinX(), is(104.0));
+        assertThat(bounds.getMaxX(), is(124.0));
+        assertThat(bounds.getMinY(), is(208.0));
+        assertThat(bounds.getMaxY(), is(224.0));
     }
 }


### PR DESCRIPTION
Closes #24

## Motivation

All game objects were using a full 32×32 bounding box for collision detection, regardless of what the sprite actually looks like. This causes false-positive collisions — e.g. the NightStalker "hits" enemies that are visually several pixels away, or a bullet appears to hit a wall it hasn't reached yet.

## Change

- Added `setBoundingBoxDimensions(offsetX, offsetY, width, height)` to `DisplayableObject`. The stored bounding box holds relative offsets; `getAbsoluteBounds()` adds the current position at query time, so the box tracks movement correctly.
- Each sprite sheet was scanned pixel-by-pixel (alpha > 10) to find the tightest bounding rectangle across its animation frames.
- Each class now calls `setBoundingBoxDimensions()` in its constructor with the per-sprite values:

| Class | offsetX | offsetY | width | height |
|---|---|---|---|---|
| Bullet | 12 | 14 | 8 | 4 |
| NightStalker | 6 | 1 | 20 | 30 |
| Spider | 0 | 4 | 32 | 22 |
| Bat | 4 | 4 | 24 | 14 |
| GreyRobot | 2 | 2 | 28 | 28 |
| Weapon | 0 | 8 | 32 | 16 |

## Test approach

TDD: failing tests were written first for every affected class, then the production code was implemented to make them pass.

- `DisplayableObjectTest.setBoundingBoxDimensionsAffectsAbsoluteBounds` — verifies the core helper at position (100, 200)
- Per-class tests (`bulletHasTightBoundingBox`, `nightStalkerHasTightBoundingBox`, `spiderHasTightBoundingBox`, `batHasTightBoundingBox`, `greyRobotHasTightBoundingBox`, `weaponHasTightBoundingBox`) — each checks that `getAbsoluteBounds()` returns the expected tight rectangle relative to the object's position.

## Test result

All 105 tests pass (`./gradlew test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)